### PR TITLE
unregister service worker, at least for development

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -10,4 +10,4 @@ ReactDOM.render(<App />, document.getElementById('root'));
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: http://bit.ly/CRA-PWA
-serviceWorker.register();
+serviceWorker.unregister();


### PR DESCRIPTION
This commit unregisters the service worker. This should clear up the caching problems we've been experiencing. We can register it when we are closer to production.